### PR TITLE
Fixed wrong number of arguments issue

### DIFF
--- a/dashboard-hackernews.el
+++ b/dashboard-hackernews.el
@@ -92,7 +92,7 @@
        (dashboard-hackernews-get-item
         (elt ids i) (lambda (item) (push item dashboard-hackernews-items))))))
   (dashboard-hackernews-insert-list "Hackernews:"
-                                    (dashboard-subseq dashboard-hackernews-items 0 list-size)))
+                                    (dashboard-subseq dashboard-hackernews-items list-size)))
 
 (provide 'dashboard-hackernews)
 ;;; dashboard-hackernews.el ends here


### PR DESCRIPTION
Currently, emacs-dashboard-hackernews crashes the entire dashboard when starting due to a wrong number of arguments issue. This is because of a fix in dashboard: https://github.com/emacs-dashboard/emacs-dashboard/pull/344

As per my understanding, it works the same with just the start-argument removed (defaulting to 0). 