### PR TITLE
Removed duplicate sections in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,23 +1,3 @@
-* emacs-dashboard-hackernews
-This is a plugin for the [[https://github.com/rakanalh/emacs-dashboard][Emacs Dashboard]].
-
-* Feature
-Display a topstories of [[https://news.ycombinator.com/][Hacker News]] on Dashboard.
-
-* ScreenShot
-[[./screenshot.png]]
-
-* Usage
-
-#+BEGIN_SRC sh
-M-x package-install RET dashboard-hackernews
-#+END_SRC
-
-#+BEGIN_SRC elisp
-(require 'dashboard-hackernews)
-(setq dashboard-items '((hackernews . 10)))
-#+END_SRC
-
 * ~emacs-dashboard-hackernews~
 This package is a plugin for the
 [[https://github.com/emacs-dashboard/emacs-dashboard][Emacs Dashboard]] which


### PR DESCRIPTION
Seems like the readme had some duplicated sections after the last PR (header twice, screenshot twice etc.). This removes the duplicates