### PR TITLE
Use same face for hackernews entries as Dashboard does for items

### DIFF
--- a/dashboard-hackernews.el
+++ b/dashboard-hackernews.el
@@ -77,6 +77,7 @@
                            :action `(lambda (&rest ignore)
                                       (browse-url ,(cdr (assoc 'url el))))
                            :mouse-face 'highlight
+                           :button-face 'dashboard-items-face
                            :follow-link "\C-m"
                            :button-prefix ""
                            :button-suffix ""


### PR DESCRIPTION
`dashboard-hackernews` does not use the same face as `dashboard` does for its items. This can lead to an inconsistent look if theme creators tries to create custom settings for dashboard. 

Let's say that the theme creator, in this case me, have overridden styling for `dashboard-items-face`, but the this extension uses the current behaviour:
<img width="825" alt="image" src="https://github.com/user-attachments/assets/6018df8e-1995-4539-9d54-f165e37b598f">

This is due to dashboard-hackernews using the default `widget-button` face for its styling. It is true that most users probably won't notice this, as many themes just use default widget styling. I still think the best course of action is to be consistent with the face settings that `dashboard` has. dashboards item face inherits from `widget-button` anyway, so most users won't notice this difference. With the settings in this PR, it uses dashboards item styling for consistency:
<img width="825" alt="image" src="https://github.com/user-attachments/assets/ee6ebac5-99b8-4f2a-b9df-e94d5333b799">

(this PR is not about my theme, but about the consistency of faces. That is best shown visually. If you don't like my theme, then you do you. I want a pink and cutesy theme 🙂  )