### PR TITLE
Update to use dashboard-insert-section for adding a shortcut and icon. 

### DIFF
--- a/README.org
+++ b/README.org
@@ -85,27 +85,29 @@ For those who require a little more context, the following is a more complicated
 configuration with ~use-package~ and ~straight.el~.
 
 #+begin_src emacs-lisp
-(use-package dashboard-hackernews
-  :straight (:type git
-             :host github
-             :repo "hyakt/emacs-dashboard-hackernews"
-             :branch "master")
-  :config
-  (require 'json))
+  (use-package dashboard-hackernews
+    :straight (:type git
+               :host github
+               :repo "hyakt/emacs-dashboard-hackernews"
+               :branch "master")
+    :config
+    (require 'json))
 
-(use-package dashboard
-  :after dashboard-hackernews
-  :config
-  (setq dashboard-banner-logo-title      "My Dashboard"    ; set the title
-        dashboard-startup-banner         'logo                   ; show the logo in the banner area
-        dashboard-set-init-info          t                       ; show package load / init time
-        dashboard-set-heading-icons      t
-        dashboard-set-file-icons         t
-        dashboard-items                  '((recents . 5)         ; this is where the magic happens
-                                           (bookmarks . 5)
-                                           (hackernews . 5)
-                                           (agenda . 5))
-        dashboard-center-content         t                       ; center the dashboard
-        dashboard-week-agenda            t)                      ; set the agenda
-  (dashboard-setup-startup-hook))
+  (use-package dashboard
+    :after dashboard-hackernews
+    :config
+    (setq dashboard-banner-logo-title       "My Dashboard"            ; set the title
+          dashboard-startup-banner          'logo                     ; show the logo in the banner area
+          dashboard-set-init-info           t                         ; show package load / init time
+          dashboard-set-heading-icons       t
+          dashboard-set-file-icons          t
+          dashboard-items                   '((recents . 5)           ; this is where the magic happens
+                                              (bookmarks . 5)
+                                              (hackernews . 5)
+                                              (agenda . 5))
+          dashboard-center-content          t                         ; center the dashboard
+          dashboard-week-agenda             t)                        ; set the agenda
+    (add-to-list 'dashboard-item-shortcuts  '(hackernews . "n"))      ; set a shortcut (optional)
+    (add-to-list 'dashboard-heading-icons   '(hackernews . "pulse"))  ; set an icon (optional)
+    (dashboard-setup-startup-hook))
 #+end_src

--- a/dashboard-hackernews.el
+++ b/dashboard-hackernews.el
@@ -92,8 +92,25 @@
      (dotimes (i list-size)
        (dashboard-hackernews-get-item
         (elt ids i) (lambda (item) (push item dashboard-hackernews-items))))))
-  (dashboard-hackernews-insert-list "Hackernews:"
-                                    (dashboard-subseq dashboard-hackernews-items list-size)))
+  (if (and (fboundp 'dashboard-insert-section)
+           (eq (car-safe (symbol-function 'dashboard-insert-section)) 'macro))
+      (dashboard-insert-section
+       "Hackernews:"
+       (mapcar (lambda (story)
+                 (propertize (format "[%3d] %s"
+                                     (alist-get 'score story)
+                                     (decode-coding-string (alist-get 'title story) 'utf-8))
+                             'dashboard-url (alist-get 'url story)))
+               dashboard-hackernews-items)
+       list-size
+       'hackernews
+       (dashboard-get-shortcut 'hackernews)
+       `(lambda (&rest _)
+          (let ((url (get-text-property 0 'dashboard-url ,el)))
+            (when url (browse-url url))))
+       el)
+    (dashboard-hackernews-insert-list "Hackernews:"
+                                      (dashboard-subseq dashboard-hackernews-items list-size))))
 
 (provide 'dashboard-hackernews)
 ;;; dashboard-hackernews.el ends here

--- a/dashboard-hackernews.el
+++ b/dashboard-hackernews.el
@@ -67,24 +67,6 @@
              (lambda (&key data &allow-other-keys)
                (funcall callback data)))))
 
-(defun dashboard-hackernews-insert-list (list-display-name list)
-  "Render LIST-DISPLAY-NAME and items of LIST."
-  (when (car list)
-    (dashboard-insert-heading list-display-name)
-    (mapc (lambda (el)
-            (insert "\n    ")
-            (widget-create 'push-button
-                           :action `(lambda (&rest ignore)
-                                      (browse-url ,(cdr (assoc 'url el))))
-                           :mouse-face 'highlight
-                           :button-face 'dashboard-items-face
-                           :follow-link "\C-m"
-                           :button-prefix ""
-                           :button-suffix ""
-                           :format "%[%t%]"
-                           (format "[%3d] %s" (cdr (assoc 'score el)) (decode-coding-string (cdr (assoc 'title el)) 'utf-8))))
-          list)))
-
 (defun dashboard-hackernews-insert (list-size)
   "Add the list of LIST-SIZE items from hackernews."
   (dashboard-hackernews-get-ids
@@ -92,25 +74,21 @@
      (dotimes (i list-size)
        (dashboard-hackernews-get-item
         (elt ids i) (lambda (item) (push item dashboard-hackernews-items))))))
-  (if (and (fboundp 'dashboard-insert-section)
-           (eq (car-safe (symbol-function 'dashboard-insert-section)) 'macro))
-      (dashboard-insert-section
-       "Hackernews:"
-       (mapcar (lambda (story)
-                 (propertize (format "[%3d] %s"
-                                     (alist-get 'score story)
-                                     (decode-coding-string (alist-get 'title story) 'utf-8))
-                             'dashboard-url (alist-get 'url story)))
-               dashboard-hackernews-items)
-       list-size
-       'hackernews
-       (dashboard-get-shortcut 'hackernews)
-       `(lambda (&rest _)
-          (let ((url (get-text-property 0 'dashboard-url ,el)))
-            (when url (browse-url url))))
-       el)
-    (dashboard-hackernews-insert-list "Hackernews:"
-                                      (dashboard-subseq dashboard-hackernews-items list-size))))
+  (dashboard-insert-section
+   "Hackernews:"
+   (mapcar (lambda (story)
+             (propertize (format "[%3d] %s"
+                                 (alist-get 'score story)
+                                 (decode-coding-string (alist-get 'title story) 'utf-8))
+                         'dashboard-url (alist-get 'url story)))
+           dashboard-hackernews-items)
+   list-size
+   'hackernews
+   (dashboard-get-shortcut 'hackernews)
+   `(lambda (&rest _)
+      (let ((url (get-text-property 0 'dashboard-url ,el)))
+        (when url (browse-url url))))
+   el))
 
 (provide 'dashboard-hackernews)
 ;;; dashboard-hackernews.el ends here


### PR DESCRIPTION
The current package doesn't let one configure a shortcut or an icon. This PR addresses that.

To add a shortcut and an icon, using a macro from `emacs-dashboard`, the insert function was updated.  It checks if the `dashboard-insert-section` macro is defined and calls it if so, else it falls back to the older routine (for backwards compatibility).

<img width="641" height="417" alt="image" src="https://github.com/user-attachments/assets/ca144ad5-91e7-4849-93c3-60c8eaabdbe2" />

Then, following the `emacs-dashboard` [configuration instructions](https://github.com/emacs-dashboard/dashboard#configuration):

You can add a dashboard shortcut by inserting something like `(hackernews . "n")` into `dashboard-item-shortcuts`.

Icons can be added by inserting `(hackernews . "pulse")` or `(hackernews . (all-the-icons-faicon "newspaper-o"))` into `dashboard-heading-icons`.

Of course, you can specify whatever shortcut and/or icon you like in the `emacs-dashboard` configuration.